### PR TITLE
* setNoDelay(true) on sockets in use to avoid Nagle's algo

### DIFF
--- a/lib/msgpack-rpc.js
+++ b/lib/msgpack-rpc.js
@@ -261,6 +261,7 @@ var Transport = function (hostname, port) {
 	var self = this;
 	this._connect_cb = cb;
 	this.tcp_stream = new net.createConnection (port, hostname);
+       this.tcp_stream.setNoDelay(true);
 	this.rpc_stream = new MsgpackRPCStream (this.tcp_stream);
 	this.rpc_stream.on ('ready', 
 			    function () { self._trigger (true, null); });
@@ -340,6 +341,7 @@ exports.createClient = function (hostname, port, cb) {
     }
 
     var conn = new net.createConnection (port, hostname);
+    conn.setNoDelay(true);
     var s = new MsgpackRPCStream (conn);
     if (cb) { s.on ('ready', cb); }
     return s;
@@ -351,6 +353,7 @@ var ServerConnection = function (server, tcpStream) {
 
     var self = this;
     this._tcpStream = tcpStream;
+    this._tcpStream.setNoDelay(true);
     this._remote = tcpStream.remoteAddress + ":" + tcpStream.remotePort;
     this._server = server;
     this._verbose = false;


### PR DESCRIPTION
I was seeing latencies of 40ms in simple services, and in services where much more data is being pushed around. These changes removed it all.
