### PR TITLE
Disable nagle on server side connections.

### DIFF
--- a/src/listener.iced
+++ b/src/listener.iced
@@ -54,6 +54,9 @@ exports.Listener = class Listener
   # Feel free to change this for your needs (if you want to wrap a connection
   # with something else)...
   make_new_transport : (c) ->
+    # Disable Nagle by default
+    c.setNoDelay true unless @do_tcp_delay
+
     x = new @TransportClass
       tcp_stream : c
       host : c.remoteAddress


### PR DESCRIPTION
Yo Max,

This duplicates the `@do_tcp _delay` variable, which might not be the best way of specifying this, but it works and lets me get ~10k ping/pong requests a second.  

I'm not sure if you'd want it to be on by default or not.
